### PR TITLE
Fix blurry graphic decoration node

### DIFF
--- a/src/main/java/net/synedra/validatorfx/GraphicDecoration.java
+++ b/src/main/java/net/synedra/validatorfx/GraphicDecoration.java
@@ -187,8 +187,8 @@ public class GraphicDecoration implements Decoration {
         
         Bounds sceneBounds = decoratedNode.localToScene(targetBounds);
         Bounds stackBounds = stack.sceneToLocal(sceneBounds);
-        decorationNode.setLayoutX(x + xOffset + stackBounds.getMinX());
-        decorationNode.setLayoutY(y + yOffset +  stackBounds.getMinY());
+        decorationNode.setLayoutX(Math.round(x + xOffset + stackBounds.getMinX()));
+        decorationNode.setLayoutY(Math.round(y + yOffset + stackBounds.getMinY()));
         addOrRemoveDecorationNodeToStack();
     }
     


### PR DESCRIPTION
close #17 https://github.com/effad/ValidatorFX/issues/17
I think it has to do with the sub-pixel positioning but I don't know enough of the internals. Rounding the x,y coordinates seems to fix the issue.